### PR TITLE
Fix company dashboard Alpine JSON embedding to resolve console errors

### DIFF
--- a/resources/views/dashboards/company.blade.php
+++ b/resources/views/dashboards/company.blade.php
@@ -66,7 +66,11 @@
             </div>
         </div>
     </div>
-            <div class="p-6 bg-white dark:bg-gray-800 rounded-xl shadow" x-data='{ prov: @js($charts["by_province"]), spec: @js($charts["by_speciality"]) }'>
+            <div class="p-6 bg-white dark:bg-gray-800 rounded-xl shadow"
+                 x-data="{ prov: [], spec: [] }"
+                 x-init="prov = JSON.parse($el.dataset.prov); spec = JSON.parse($el.dataset.spec)"
+                 data-prov='@json($charts["by_province"])'
+                 data-spec='@json($charts["by_speciality"])'>
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                     <div>
                         <div class="text-sm text-gray-500 mb-2">أعلى المحافظات</div>


### PR DESCRIPTION
Summary
- Fix Alpine initialization on the company dashboard where JSON embedded in x-data caused syntax errors in production (malformed quotes leading to `expected expression, got '}'` and undefined `prov/spec`).

Change details
- resources/views/dashboards/company.blade.php:
  - Replace direct x-data JSON embedding with safe data-* attributes and x-init parsing:
    - x-data="{ prov: [], spec: [] }"
    - x-init parses JSON from data-prov and data-spec attributes using @json.
  - This prevents HTML attribute quoting issues across environments and clears the console errors.

Why
- Browsers received broken Alpine expressions due to quote escaping around the JSON, breaking the dashboard charts for company users.

Impact
- Company dashboard charts render correctly.
- No behavior change outside of this view.

Verification
- Tested locally by rendering the dashboard; no Alpine errors and bars render as expected.

Notes
- Related production symptoms included 404s on company routes when logged in with non-company roles; that behavior is handled via RoleMiddleware in the codebase (separate from this view change).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author